### PR TITLE
BOSA21Q1-16 Front office: in the conversation module > delete the limitation of characters in a conversation

### DIFF
--- a/lib/extends/decidim-core/app/models/decidim/messaging/message.rb
+++ b/lib/extends/decidim-core/app/models/decidim/messaging/message.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module MessageExtend
+  extend ActiveSupport::Concern
+
+  included do
+    clear_validators!
+    validates :sender, :body, presence: true
+
+    validate :sender_is_participant
+  end
+end
+
+Decidim::Messaging::Message.send(:include, MessageExtend)


### PR DESCRIPTION
Recent changes from bosa: https://github.com/belighted/bosa/pull/91