### PR TITLE
BOSA21Q1-169 BOSA cities: in menu, highlight the right page you're on

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/belighted/decidim-module-navbar_links
-  revision: feb5f778004b2e1f003ff1de4f84e0f4667dbe46
+  revision: c84b70b6934fcccff677ba2b3bf209bbb4397065
   branch: 0.22.0
   specs:
     decidim-navbar_links (0.22.0)

--- a/lib/extends/decidim-core/lib/decidim/menu.rb
+++ b/lib/extends/decidim-core/lib/decidim/menu.rb
@@ -1,0 +1,35 @@
+# Clear menu items to reorder
+Decidim::MenuRegistry.destroy(:menu)
+
+Decidim.menu :menu do |menu|
+
+  menu.item I18n.t("menu.home", scope: "decidim"),
+            decidim.root_path,
+            position: 1,
+            active: :exclusive
+
+  menu.item I18n.t("menu.processes", scope: "decidim"),
+            decidim_participatory_processes.participatory_processes_path,
+            position: 2,
+            if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?,
+            active: :exclusive
+
+  Decidim::NavbarLinks::NavbarLink.organization(current_organization).each do |navbar_link|
+    menu.item translated_attribute(navbar_link.title),
+              navbar_link.link,
+              position: 3,
+              active: :inclusive
+  end
+
+  menu.item I18n.t("menu.assemblies", scope: "decidim"),
+            decidim_assemblies.assemblies_path,
+            position: 4,
+            if: Decidim::Assembly.where(organization: current_organization).published.any?,
+            active: :inclusive
+
+  menu.item I18n.t("menu.help", scope: "decidim"),
+            decidim.pages_path,
+            position: 5,
+            active: :inclusive
+
+end


### PR DESCRIPTION
## Description
- What?
- - As a user, when I clic on "Grande enquête nationale" in the menu, it is "Concertations" that is highlighted and not the tab "Grande enquête nationale".
- Why?
- - The active method set an incorrect value :exclusive. The correct value is :inclusive
- How?
- - Override the menu.rb in the extends

## Ticket
[BOSA21Q1-169](https://belighted.atlassian.net/browse/BOSA21Q1-169?atlOrigin=eyJpIjoiOTRlNjkzNGY2NjVjNGU2NGEyOTNmNzEwNDFjZGE4NGYiLCJwIjoiaiJ9)

## Type of changes

- [ ]  Docs changes
- [ ]  Refactoring
- [x]  Dependency upgrade
- [ ]  Bug fix
- [x]  New feature
- [ ]  Breaking changes