### PR TITLE
BOSA21Q1-357: fix displaying list with links

### DIFF
--- a/app/assets/stylesheets/decidim/extends/_external-link.scss
+++ b/app/assets/stylesheets/decidim/extends/_external-link.scss
@@ -1,0 +1,7 @@
+.section, .static__content {
+  ul, ol {
+    .external-link-container {
+      display: inline;
+    }
+  }
+}


### PR DESCRIPTION
Updated:

The list which contains the link with long text is not properly
displayed. This is caused by displaying external-link-container in block
mode in the section or static__content cases. Changing display mode to
inline is fixing this issue.

(cherry picked from commit bdc747a)