### PR TITLE
BOSA21Q1-393: fix issue with displaying links in the footer

### DIFF
--- a/app/views/layouts/decidim/_wrapper.html.erb
+++ b/app/views/layouts/decidim/_wrapper.html.erb
@@ -135,7 +135,7 @@ end
           <%= yield %>
         </main>
       </div><!-- /.footer-separator -->
-      <% cache [current_organization, I18n.locale, 'wrapper', 'footer'] do %>
+      <% cache [current_organization, I18n.locale, 'wrapper', 'footer', "cookies_accepted:#{cookies_accepted?}"] do %>
         <%= render partial: "layouts/decidim/main_footer" %>
         <%= render partial: "layouts/decidim/mini_footer" %>
       <% end %>


### PR DESCRIPTION
Updated:

I have made tweaks for our cache key definition for footer parts to
display reset link for cookie policy. In the result we can display
footer in different states.

(cherry picked from commit ef33e05)